### PR TITLE
feat(workflows): update Coolify webhook trigger workflow

### DIFF
--- a/.github/workflows/coolify-webhook.yml
+++ b/.github/workflows/coolify-webhook.yml
@@ -3,20 +3,13 @@ name: Coolify Webhook Trigger
 on:
   pull_request:
     branches: [main]
-    types: [opened, synchronize, closed]
+    types: [closed]
   workflow_dispatch:
-    inputs:
-      event_type:
-        description: "Tipo de evento para simular"
-        required: true
-        default: "pull_request"
-        type: choice
-        options:
-          - pull_request
 
 jobs:
   trigger-webhook:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     steps:
       - name: Checkout código
         uses: actions/checkout@v3
@@ -29,68 +22,28 @@ jobs:
           node-version: "18"
 
       - name: Instalar dependências
-        run: npm install axios crypto
+        run: npm install axios
 
-      - name: Trigger Coolify Webhook
+      - name: Trigger Coolify Deploy
         uses: actions/github-script@v6
         with:
           script: |
             const axios = require('axios');
-            const crypto = require('crypto');
 
-            const webhookUrl = 'https://dev.lkgiovani.com/webhooks/source/github/events/manual';
-            const secret = 'salve';
+            const deployUrl = 'https://dev.lkgiovani.com/api/v1/deploy?uuid=s8s0oksoks4c4s04ckckoggw&force=false';
 
-            // Sempre será um evento de pull request
-            const eventType = 'pull_request';
-
-            // Cria um payload similar ao do GitHub
-            const payload = {
-              repository: {
-                name: context.repo.repo,
-                full_name: `${context.repo.owner}/${context.repo.repo}`,
-                owner: {
-                  login: context.repo.owner
-                }
-              },
-              pull_request: {
-                number: context.payload.pull_request?.number || 1,
-                state: context.payload.pull_request?.state || 'open',
-                title: context.payload.pull_request?.title || 'Pull Request para main',
-                base: {
-                  ref: 'main'
-                }
-              }
-            };
-
-            // Serializa o payload
-            const payloadString = JSON.stringify(payload);
-
-            // Cria a assinatura HMAC SHA-256, similar ao X-Hub-Signature do GitHub
-            const signature = crypto
-              .createHmac('sha256', secret)
-              .update(payloadString)
-              .digest('hex');
-
-            console.log(`Enviando webhook para ${webhookUrl}`);
+            console.log(`Enviando requisição de deploy para ${deployUrl}`);
 
             try {
-              const response = await axios.post(webhookUrl, payload, {
-                headers: {
-                  'Content-Type': 'application/json',
-                  'X-GitHub-Event': eventType,
-                  'X-Hub-Signature-256': `sha256=${signature}`,
-                  'X-GitHub-Delivery': crypto.randomUUID()
-                }
-              });
+              const response = await axios.get(deployUrl);
               
               console.log(`Status: ${response.status}`);
-              console.log('Webhook enviado com sucesso!');
+              console.log('Deploy iniciado com sucesso!');
             } catch (error) {
-              console.error('Erro ao enviar webhook:', error.message);
+              console.error('Erro ao iniciar deploy:', error.message);
               if (error.response) {
                 console.error(`Status: ${error.response.status}`);
                 console.error('Response:', error.response.data);
               }
-              core.setFailed('Falha ao enviar webhook para Coolify');
+              core.setFailed('Falha ao iniciar deploy no Coolify');
             }


### PR DESCRIPTION
- Altered the `coolify-webhook.yml` to trigger the workflow only on closed pull requests.
- Removed unnecessary workflow dispatch inputs related to event types.
- Simplified the installation step by removing the `crypto` dependency.
- Updated the webhook trigger step to initiate a deploy request instead of sending a webhook, changing the URL and method from POST to GET.
- Enhanced logging messages to reflect the new deploy process.

These changes streamline the Coolify webhook trigger workflow by focusing on closed pull requests and simplifying the deployment process. By removing unnecessary dependencies and inputs, the workflow becomes more efficient and easier to maintain, ultimately improving the integration with the Coolify deployment service.