### PR TITLE
feat(workflows): update Coolify webhook workflow for production deplo…

### DIFF
--- a/.github/workflows/coolify-webhook.yml
+++ b/.github/workflows/coolify-webhook.yml
@@ -7,9 +7,11 @@ on:
   workflow_dispatch:
 
 jobs:
-  trigger-webhook:
+  deploy-prd:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    environment: Production
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+
     steps:
       - name: Checkout código
         uses: actions/checkout@v3
@@ -21,8 +23,8 @@ jobs:
           echo "Enviando requisição de deploy para Coolify..."
           HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
             -X GET \
-            -H "Authorization: Bearer 1|ucxqam9OaI4SGTuNfmCeXvZ6NHrbs0McdeMfEFJb35beb3e1" \
-            "https://dev.lkgiovani.com/api/v1/deploy?uuid=s8s0oksoks4c4s04ckckoggw&force=false")
+            -H "Authorization: Bearer ${{ secrets.COOLIFY_API_TOKEN }}" \
+            "${{ secrets.COOLIFY_UUID }}api/v1/deploy?uuid=${{ secrets.COOLIFY_BASE_URL }}&force=${{ secrets.COOLIFY_FORCE_DEPLOY }}")
 
           if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
             echo "Deploy iniciado com sucesso! Status: $HTTP_STATUS"


### PR DESCRIPTION
…yment

- Renamed the job from `trigger-webhook` to `deploy-prd` to better reflect its purpose.
- Changed the workflow trigger condition to activate on pushes to the `main` branch instead of merged pull requests.
- Added an `environment` specification for Production to clarify the deployment context.
- Updated the authorization header in the deployment request to use GitHub secrets for enhanced security.
- Modified the deployment URL to utilize secrets for the UUID and base URL, improving flexibility and security.

Essas alterações aprimoram o fluxo de trabalho do webhook do Coolify, garantindo que o processo de implantação ocorra apenas em pushes para a branch principal, o que é mais adequado para um ambiente de produção. A utilização de segredos do GitHub para a autenticação e a URL de implantação aumenta a segurança e a manutenibilidade do código, reduzindo o risco de exposição de informações sensíveis. Essas melhorias contribuem para um processo de implantação mais seguro e eficiente no projeto.